### PR TITLE
Allow to disable event publishing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,9 +38,10 @@ exports.getDispatcher = function (emit, socketKey) {
       // The reference between connection and socket
       // is set in `app.setup`
       const socket = connection[socketKey];
+      const data = channel.dataFor(connection) ||
+        (hook.dispatch !== undefined ? hook.dispatch : hook.result);
 
-      if (socket) {
-        const data = channel.dataFor(connection) || hook.dispatch || hook.result;
+      if (socket && data) {
         const eventName = `${hook.path || ''} ${event}`.trim();
 
         debug(`Dispatching '${eventName}' to Socket ${socket.id} with`, data);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -112,6 +112,15 @@ describe('socket commons utils', () => {
         dispatcher('testing', dummyChannel, dummyHook);
       });
 
+      it('dispatches nothing if `hook.dispatch` set to falsy', done => {
+        dummyHook.dispatch = null;
+
+        dummySocket.once('testing', data => done(new Error('should never get here')));
+
+        dispatcher('testing', dummyChannel, dummyHook);
+        done();
+      });
+
       it('does nothing if there is no socket', () => {
         dummyChannel.connections[0].test = null;
 


### PR DESCRIPTION
By setting `hook.dispatch` to `null`.