### PR TITLE
Fix dispatching of arrays

### DIFF
--- a/lib/channels/index.js
+++ b/lib/channels/index.js
@@ -62,7 +62,7 @@ function channels () {
             const channel = new CombinedChannel(results);
 
             if (channel && channel.length > 0) {
-              app.emit('publish', event, channel, hook);
+              app.emit('publish', event, channel, hook, data);
             } else {
               debug('No connections to publish to');
             }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -132,7 +132,8 @@ describe('socket commons utils', () => {
           });
         });
 
-        dispatcher('testing', dummyChannel, dummyHook);
+        dispatcher('testing', dummyChannel, dummyHook, data1);
+        dispatcher('testing', dummyChannel, dummyHook, data2);
       });
     });
   });


### PR DESCRIPTION
Because https://github.com/feathersjs/feathers/pull/743 already sends multiple events for multiple entries we can just go through the whole list again. We have to find the individual data entry and its dispatch equivalent and send that one.